### PR TITLE
get_steps_values & steps

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -318,6 +318,9 @@ grain_worker_count: 1
 steps: 150_001 # If set to -1 then will inherit value from learning_rate_schedule_steps
 log_period: 100 # Flushes Tensorboard
 
+# Training steps per loop
+steps_per_loop: 100
+
 # We take inspiration from Llama2's learning rate (LR) schedule, see https://arxiv.org/pdf/2307.09288.pdf section 2.2
 # Learning rate schedule has either two or three parts:
 # 1) Linear warmup from 0 to [learning_rate] over steps 0 to [learning_rate_schedule_steps * warmup_steps_fraction]

--- a/MaxText/ray_trainer.py
+++ b/MaxText/ray_trainer.py
@@ -102,8 +102,6 @@ def main(argv: Sequence[str]):
   logging.info("Initialization complete. Starting MaxText training...")
   steps, steps_per_loop = get_steps_values(argv)
   logging.info(f"KubeRay training running for total steps: {steps}, steps per loop: {steps_per_loop}")
-  # steps = argv.steps #50 #int(args.steps)
-  # steps_per_loop = argv.steps_per_loop #100 #int(args.steps_per_loop)
   steps_counter = 0
 
   while steps_counter < steps:


### PR DESCRIPTION
Retrieve get_steps_values & steps from argv and some minor cleanup.

Verified with ray job submit below.
```
ray job submit --working-dir "." --runtime-env-json='{"excludes": [".github", "MaxText/test_assets", ".vscode", "test_assets", "getting_started", "end_to_end", "venv", ".git", "pedagogical_examples"],"includes":["assets/"]}' -- python3 MaxText/ray_trainer.py MaxText/configs/base.yml steps=10 steps_per_loop=60  base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH model_name=llama2-7b per_device_batch_size=2  max_target_length=8192 tokenizer_path="assets/tokenizer.llama2" reuse_example_batch=1 ici_fsdp_parallelism=-1 attention='flash' enable_checkpointing=false sa_block_q_dq=2048 sa_block_q_dkv=2048 sa_block_q=1024 profiler="xplane" use_iota_embed=true remat_policy=full gcs_metrics=false

```